### PR TITLE
Style: Unify button styles in code panel

### DIFF
--- a/src/components/builder/BaseBuilder.jsx
+++ b/src/components/builder/BaseBuilder.jsx
@@ -546,10 +546,10 @@ export default function BaseBuilder({ title, palette, storageKey, schemas, build
                 <div className="code-header">
                   <div className="code-title">Generated Code</div>
                   <div className="flex space-x-2">
-                    <button onClick={() => setShowRawCode(!showRawCode)} className="builder-btn code-show-raw-btn">
+                    <button onClick={() => setShowRawCode(!showRawCode)} className="builder-btn">
                       {showRawCode ? 'Formatted' : 'Raw'}
                     </button>
-                    <button onClick={_copyCode} className="code-copy-btn">
+                    <button onClick={_copyCode} className="builder-btn">
                       <TbCopy /> Copy
                     </button>
                   </div>

--- a/src/styles/builder.css
+++ b/src/styles/builder.css
@@ -222,15 +222,6 @@
   color: #cbd5e1;
 }
 
-.code-copy-btn {
-  padding: 6px 12px;
-  font-size: 12px;
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
-}
-
-.code-show-raw-btn {
-  background: #4a5568;
-}
 
 .code-content {
   flex: 1;


### PR DESCRIPTION
This commit updates the styling of the "Show Raw" and "Copy" buttons in the code panel to use the main `builder-btn` class, making them consistent with the other buttons in the application.

The unused CSS classes `.code-copy-btn` and `.code-show-raw-btn` have been removed.