### PR TITLE
Style: Unify button styles and sizes

### DIFF
--- a/src/styles/builder.css
+++ b/src/styles/builder.css
@@ -34,6 +34,10 @@
   cursor: pointer;
   box-shadow: 0 10px 15px -3px rgba(34,197,94,0.28);
   transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 .builder-btn:hover { transform: translateY(-2px); box-shadow: 0 18px 25px -10px rgba(59,130,246,0.35); }
 .builder-btn:active { transform: translateY(0); opacity: 0.95; }


### PR DESCRIPTION
This commit updates the styling of the `.builder-btn` class to ensure that buttons with and without icons have the same size. It adds `display: inline-flex`, `align-items: center`, `justify-content: center`, and `gap` to the button style.